### PR TITLE
Download chart dependencies

### DIFF
--- a/src/hrval-all.sh
+++ b/src/hrval-all.sh
@@ -8,6 +8,10 @@ KUBE_VER=${3-master}
 HELM_VER=${4-v2}
 HRVAL="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/hrval.sh"
 
+if [[ ${HELM_VER} == "v2" ]]; then
+    helm init --client-only
+fi
+
 if test -f "${DIR}"; then
   ${HRVAL} ${DIR} ${IGNORE_VALUES} ${KUBE_VER} ${HELM_VER}
   exit 0

--- a/src/hrval.sh
+++ b/src/hrval.sh
@@ -77,11 +77,18 @@ function validate {
 
   echo "Writing Helm release to ${TMPDIR}/${HELM_RELEASE_NAME}.release.yaml"
   if [[ ${HELM_VER} == "v3" ]]; then
+    # Helm v3 bug: https://github.com/helm/helm/issues/6416
+#    if [[ "${CHART_PATH}" != "null" ]]; then
+#      helmv3 dependency build ${CHART_TAR}
+#    fi
     helmv3 template ${HELM_RELEASE_NAME} ${CHART_TAR} \
       --namespace ${HELM_RELEASE_NAMESPACE} \
       --skip-crds=true \
       -f ${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml > ${TMPDIR}/${HELM_RELEASE_NAME}.release.yaml
   else
+    if [[ "${CHART_PATH}" != "null" ]]; then
+      helm dependency build ${CHART_TAR}
+    fi
     helm template ${CHART_TAR} \
       --name ${HELM_RELEASE_NAME} \
       --namespace ${HELM_RELEASE_NAMESPACE} \

--- a/test/ghost.yaml
+++ b/test/ghost.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ghost
+  namespace: demo
+spec:
+  releaseName: ghost
+  chart:
+    git: https://github.com/fluxcd/flux-get-started
+    ref: master
+    path: charts/ghost
+  values:
+    image: bitnami/ghost:1.21.5-r0
+    persistence:
+      enabled: false
+    resources:
+      requests:
+        memory: 32Mi
+        cpu: 10m
+    serviceType: ClusterIP
+    mariadb:
+      persistence:
+        enabled: false


### PR DESCRIPTION
Run `helm dependency build` for charts coming from Git repositories.

**Note** that downloading chart dependencies with Helm v3-beta.4 is broken https://github.com/helm/helm/issues/6416

Fix: #8 
