### PR TITLE
Fix broken sed expression and #20

### DIFF
--- a/src/hrval.sh
+++ b/src/hrval.sh
@@ -37,7 +37,7 @@ function clone {
   ORIGIN=$(git rev-parse --show-toplevel)
   GIT_REPO=$(yq r ${1} spec.chart.git)
   if [[ -n "${GITHUB_TOKEN}" ]]; then
-    BASE_URL=$(echo "${GIT_REPO}" | sed 's/ssh:\/\/git@//')
+    BASE_URL=$(echo "${GIT_REPO}" | sed -e 's/ssh:\/\///' -e 's/git@//' -e 's/:/\//')
     GIT_REPO="https://${GITHUB_TOKEN}:x-oauth-basic@${BASE_URL}"
   fi
   GIT_REF=$(yq r ${1} spec.chart.ref)


### PR DESCRIPTION
Separates  removing the `ssh://` and `git@` prefixes into two expressions. Additionally, replaces `:` with `/`.

This means the initial `$GIT_REPO`  variable can be something like `git@github.com:my-org/my-repo` and still be cloned by this function, avoiding `URL using bad/illegal format or missing URL` errors.