### PR TITLE
Properly Test if ${CHART_PATH} Exists

### DIFF
--- a/src/hrval.sh
+++ b/src/hrval.sh
@@ -82,7 +82,7 @@ function validate {
   echo "Writing Helm release to ${TMPDIR}/${HELM_RELEASE_NAME}.release.yaml"
   if [[ ${HELM_VER} == "v3" ]]; then
     # Helm v3 bug: https://github.com/helm/helm/issues/6416
-#    if [[ -z "${CHART_PATH}" ]]; then
+#    if [[ "${CHART_PATH}" ]]; then
 #      helmv3 dependency build ${CHART_DIR}
 #    fi
     helmv3 template ${HELM_RELEASE_NAME} ${CHART_DIR} \
@@ -90,7 +90,7 @@ function validate {
       --skip-crds=true \
       -f ${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml > ${TMPDIR}/${HELM_RELEASE_NAME}.release.yaml
   else
-    if [[ -z "${CHART_PATH}" ]]; then
+    if [[ "${CHART_PATH}" ]]; then
       helm dependency build ${CHART_DIR}
     fi
     helm template ${CHART_DIR} \

--- a/src/hrval.sh
+++ b/src/hrval.sh
@@ -60,7 +60,7 @@ function validate {
   TMPDIR=$(mktemp -d)
   CHART_PATH=$(yq r ${HELM_RELEASE} spec.chart.path)
 
-  if [[ "${CHART_PATH}" == "" ]]; then
+  if [[ -z "${CHART_PATH}" ]]; then
     echo "Downloading to ${TMPDIR}"
     CHART_DIR=$(download ${HELM_RELEASE} ${TMPDIR}| tail -n1)
   else
@@ -82,7 +82,7 @@ function validate {
   echo "Writing Helm release to ${TMPDIR}/${HELM_RELEASE_NAME}.release.yaml"
   if [[ ${HELM_VER} == "v3" ]]; then
     # Helm v3 bug: https://github.com/helm/helm/issues/6416
-#    if [[ "${CHART_PATH}" != "" ]]; then
+#    if [[ -z "${CHART_PATH}" ]]; then
 #      helmv3 dependency build ${CHART_DIR}
 #    fi
     helmv3 template ${HELM_RELEASE_NAME} ${CHART_DIR} \
@@ -90,7 +90,7 @@ function validate {
       --skip-crds=true \
       -f ${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml > ${TMPDIR}/${HELM_RELEASE_NAME}.release.yaml
   else
-    if [[ "${CHART_PATH}" != "" ]]; then
+    if [[ -z "${CHART_PATH}" ]]; then
       helm dependency build ${CHART_DIR}
     fi
     helm template ${CHART_DIR} \


### PR DESCRIPTION
- Catch case where the value of `${CHART_PATH}` is `null`. Currently the check is only for an empty string.
- Similarly, if the value of `${CHART_PATH}` is not `null`, run `helm dependency build`.