### PR TITLE
added support Gitlab CI token

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 ```
 
+Gitlab CI Token is also possible using `GITLAB_CI_TOKEN`.
+
 ## CI alternatives
 
 The validation scripts can be used in any CI system. 

--- a/src/hrval.sh
+++ b/src/hrval.sh
@@ -39,6 +39,9 @@ function clone {
   if [[ -n "${GITHUB_TOKEN}" ]]; then
     BASE_URL=$(echo "${GIT_REPO}" | sed -e 's/ssh:\/\///' -e 's/git@//' -e 's/:/\//')
     GIT_REPO="https://${GITHUB_TOKEN}:x-oauth-basic@${BASE_URL}"
+  elif [[ -n "${GITLAB_CI_TOKEN}" ]]; then
+    BASE_URL=$(echo "${GIT_REPO}" | sed -e 's/ssh:\/\///' -e 's/git@//' -e 's/:/\//')
+    GIT_REPO="https://gitlab-ci-token:${GITLAB_CI_TOKEN}@${BASE_URL}"
   fi
   GIT_REF=$(yq r ${1} spec.chart.ref)
   CHART_PATH=$(yq r ${1} spec.chart.path)


### PR DESCRIPTION
Make possible to use Gitlab CI token passing the variable GITLAB_CI_TOKEN.
It will cover #30
