### PR TITLE
Add AWS S3 repo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 ```
 
+If you set `awsS3Repo: true`,  make sure you set the appropriate environment variables for helm s3 plugin to work.  Example:
+```yaml
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  hrval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Validate Helm Releases in test dir
+        uses: stefanprodan/hrval-action@v3.1.0
+        with:
+          helmRelease: test/
+          awsS3Repo: true
+          awsS3RepoName: example-s3-helm-repo
+          awsS3Plugin: https://github.com/hypnoglow/helm-s3.git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-east-1"
+
+```
+
 Gitlab CI Token is also possible using `GITLAB_CI_TOKEN`.
 
 ## CI alternatives

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,15 @@ inputs:
   helmVersion:
     description: 'Version of Helm to validate against'
     default: 'v2'
+  awsS3Repo:
+    description: '(Optional) Set to true if using an AWS S3 Helm Repo'
+    default: false
+  awsS3RepoName:
+    description: '(Optional) The name of the AWS S3 Helm repo, if awsS3Repo was set to true'
+    default: ''
+  awsS3Plugin:
+    description: '(Optional) AWS S3 Plugin to be used in the helm plugin install command'
+    default: ''
 outputs:
   numFilesTested:
     description: The number of HelmRelease files which were tested
@@ -29,3 +38,6 @@ runs:
     - ${{ inputs.ignoreValues }}
     - ${{ inputs.kubernetesVersion }}
     - ${{ inputs.helmVersion }}
+    - ${{ inputs.awsS3Repo }}
+    - ${{ inputs.awsS3RepoName }}
+    - ${{ inputs.awsS3RepoPlugin }}

--- a/src/hrval-all.sh
+++ b/src/hrval-all.sh
@@ -7,9 +7,18 @@ IGNORE_VALUES=${2-false}
 KUBE_VER=${3-master}
 HELM_VER=${4-v2}
 HRVAL="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/hrval.sh"
+AWS_S3_REPO=${5-false}
+AWS_S3_REPO_NAME=${6-""}
+AWS_S3_PLUGIN={$7-""}
 
 if [[ ${HELM_VER} == "v2" ]]; then
     helm init --client-only
+fi
+
+if [[ ${AWS_S3_REPO} == true ]]; then
+    helm plugin install ${AWS_S3_PLUGIN}
+    helm repo add ${AWS_S3_REPO_NAME} s3:/${AWS_S3_REPO_NAME}/charts
+    helm repo update
 fi
 
 # If the path provided is actually a file, just run hrval against this one file


### PR DESCRIPTION
## hrval-action needs aws s3 helm repo support

### Purpose
I added a step before "Validate Helm Release from Helm Repo" to install helm s3 plugin but the step "Validate Helm Release from Helm Repo" overwrites my changes, so the main code needs to be updated AFAIK.
### Changes:
I'm new to GH actions however I think I did this right.  Please feel free to suggest changes or make changes as you see fit to make this work.  Changes can be seen in "files changed" tab.

### Tests:
I did not test this, I only tested my first approach listed in the purpose section and that failed miserably.

### Launch Plan:
code owner merges
