### PR TITLE
Use garethr/kubeval docker image as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.13
+FROM garethr/kubeval:latest
+
+RUN apk --no-cache add curl bash
 
 COPY LICENSE README.md /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM garethr/kubeval:latest
 
-RUN apk --no-cache add curl bash
+RUN apk --no-cache add curl bash git
 
 COPY LICENSE README.md /
 

--- a/src/deps.sh
+++ b/src/deps.sh
@@ -4,8 +4,6 @@ set -o errexit
 
 curl -sL https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 
-curl -sL https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz | tar xz && mv kubeval /bin/kubeval
-
 curl -sL https://github.com/mikefarah/yq/releases/download/3.1.0/yq_linux_amd64 -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
 curl -sSL https://get.helm.sh/helm-v2.16.3-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64


### PR DESCRIPTION
This PR changes Dockerfile base image to `garethr/kubeval:latest` and removes downloading kubeval with curl.

This results in much smaller image (950MB => 174MB).