### PR TITLE
fix for Helmv3 download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM garethr/kubeval:latest
 
-RUN apk --no-cache add curl bash git
+RUN apk --no-cache add curl bash git openssh-client
 
 COPY LICENSE README.md /
 

--- a/src/hrval.sh
+++ b/src/hrval.sh
@@ -28,8 +28,15 @@ function download {
   CHART_NAME=$(yq r ${1} spec.chart.name)
   CHART_VERSION=$(yq r ${1} spec.chart.version)
   CHART_DIR=${2}/${CHART_NAME}
-  helm repo add ${CHART_NAME} ${CHART_REPO}
-  helm fetch --version ${CHART_VERSION} --untar ${CHART_NAME}/${CHART_NAME} --untardir ${2}
+
+  if [[ ${HELM_VER} == "v3" ]]; then
+    helmv3 repo add ${CHART_NAME} ${CHART_REPO}
+    helmv3 fetch --version ${CHART_VERSION} --untar ${CHART_NAME}/${CHART_NAME} --untardir ${2}
+  else
+    helm repo add ${CHART_NAME} ${CHART_REPO}
+    helm fetch --version ${CHART_VERSION} --untar ${CHART_NAME}/${CHART_NAME} --untardir ${2}
+  fi
+
   echo ${CHART_DIR}
 }
 


### PR DESCRIPTION
This fixes downloading charts with Helm version 3.

Before this patch, validation was not working for Helm Releases, which specify charts in http repositories, while do not have `path` property in their spec.

Might be related to https://github.com/stefanprodan/hrval-action/issues/27

Also adds `openssh-client` install, since `garethr/kubeval:latest` was missing that.
