### PR TITLE
Add support for sourcing chart from head ref when testing pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,17 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Validate Helm Releases in test dir
-        uses: stefanprodan/hrval-action@v3.1.0
+        uses: stefanprodan/hrval-action@v3.2.0
         with:
           helmRelease: test/
       - name: Validate Helm Release from Helm Repo
-        uses: stefanprodan/hrval-action@v3.1.0
+        uses: stefanprodan/hrval-action@v3.2.0
         with:
           helmRelease: test/flagger.yaml
           helmVersion: v2
           kubernetesVersion: 1.17.0
       - name: Validate Helm Release from Git Repo
-        uses: stefanprodan/hrval-action@v3.1.0
+        uses: stefanprodan/hrval-action@v3.2.0
         with:
           helmRelease: test/podinfo.yaml
           helmVersion: v3
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Validate Helm Releases in test dir
-        uses: stefanprodan/hrval-action@v3.1.0
+        uses: stefanprodan/hrval-action@v3.2.0
         with:
           helmRelease: test/
         env:
@@ -108,7 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Validate Helm Releases in test dir
-        uses: stefanprodan/hrval-action@v3.1.0
+        uses: stefanprodan/hrval-action@v3.2.0
         with:
           helmRelease: test/
           awsS3Repo: true
@@ -123,6 +123,33 @@ jobs:
 ```
 
 Gitlab CI Token is also possible using `GITLAB_CI_TOKEN`.
+
+## Usage with pull requests containing changes of Helm chart source located in base repository branch
+
+If a base repository branch of pull request is referenced in helm release,
+you need to pass `HRVAL_BASE_BRANCH` and `HRVAL_HEAD_BRANCH` environment variables
+to an action to make sure it will check out amended version of the chart
+from a head repository branch.
+
+
+```yaml
+name: CI
+
+on: [pull_request]
+
+jobs:
+  hrval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Validate Helm Releases in test dir
+        uses: stefanprodan/hrval-action@v3.2.0
+        with:
+          helmRelease: test/
+        env:
+          HRVAL_BASE_BRANCH: ${{ github.base_ref }}
+          HRVAL_HEAD_BRANCH: ${{ github.head_ref }}
+```
 
 ## CI alternatives
 


### PR DESCRIPTION
This is based on https://github.com/stefanprodan/hrval-action/pull/33 and intended to solve the same problem. 

How to clone a right helm chart source in the case when helm chart referenced in a helm release being tested by `hrval-action` is located in the same git repository, where `hrval-action` is run ? 

In case of pull request, if a pull request base repository branch is referenced in helm release, `hrval-action` might be executed against invalid version of helm chart source, other than one contained in head repository branch.

Algorithm:
  - when `HRVAL_BASE_BRANCH` and `HRVAL_HEAD_BRANCH` environment variables are set, for each helm chart being tested,
     - detect if Helm Release chart reference contains link to a repository where  `hrval-action` currently runs and the `ref` specified equals to value specified in `HRVAL_BASE_BRANCH` environment variable
     - if such Helm Release have been encountered, fetch chart source from git ref specified in `HRVAL_HEAD_BRANCH` environment variable
     - otherwise, proceed with original `ref` setting

This patch is non-intrusive, and a pre-patch behavior will be executed in case if `HRVAL_BASE_BRANCH` and `HRVAL_HEAD_BRANCH` variables are not set.