### PR TITLE
Setting repo name to be the md5sum of the registry

### DIFF
--- a/src/hrval.sh
+++ b/src/hrval.sh
@@ -28,13 +28,17 @@ function download {
   CHART_NAME=$(yq r ${1} spec.chart.name)
   CHART_VERSION=$(yq r ${1} spec.chart.version)
   CHART_DIR=${2}/${CHART_NAME}
+  
+  CHART_REPO_MD5=`/bin/echo $CHART_REPO | /usr/bin/md5sum | cut -f1 -d" "`
 
   if [[ ${HELM_VER} == "v3" ]]; then
-    helmv3 repo add ${CHART_NAME} ${CHART_REPO}
-    helmv3 fetch --version ${CHART_VERSION} --untar ${CHART_NAME}/${CHART_NAME} --untardir ${2}
+    helmv3 repo add ${CHART_REPO_MD5} ${CHART_REPO}
+    helm3 repo update
+    helmv3 fetch --version ${CHART_VERSION} --untar ${CHART_REPO_MD5}/${CHART_NAME} --untardir ${2}
   else
-    helm repo add ${CHART_NAME} ${CHART_REPO}
-    helm fetch --version ${CHART_VERSION} --untar ${CHART_NAME}/${CHART_NAME} --untardir ${2}
+    helm repo add ${CHART_REPO_MD5} ${CHART_REPO}
+    helm repo update
+    helm fetch --version ${CHART_VERSION} --untar ${CHART_REPO_MD5}/${CHART_NAME} --untardir ${2}
   fi
 
   echo ${CHART_DIR}


### PR DESCRIPTION
This has decreased our build time and also improved consistency.

This now adds a helm repo to the local cache for each registry reference rather than one per chart reference. 