### PR TITLE
fix: strip .git off url properly

### DIFF
--- a/src/hrval.sh
+++ b/src/hrval.sh
@@ -61,8 +61,8 @@ function clone {
   CHART_GIT_REPO=$(yq r ${1} spec.chart.git)
   RELEASE_GIT_REPO=$(git remote get-url origin)
 
-  CHART_BASE_URL=$(basename $(echo "${CHART_GIT_REPO}" | sed -e 's/ssh:\/\///' -e 's/http:\/\///' -e 's/https:\/\///' -e 's/git@//' -e 's/:/\//') .git )
-  RELEASE_BASE_URL=$(basename $(echo "${RELEASE_GIT_REPO}" | sed -e 's/ssh:\/\///' -e 's/http:\/\///' -e 's/https:\/\///' -e 's/git@//' -e 's/:/\//') .git )
+  CHART_BASE_URL=$(echo "${CHART_GIT_REPO}" | sed -e 's/ssh:\/\///' -e 's/http:\/\///' -e 's/https:\/\///' -e 's/git@//' -e 's/:/\//' -e 's/\.git$//')
+  RELEASE_BASE_URL=$(echo "${RELEASE_GIT_REPO}" | sed -e 's/ssh:\/\///' -e 's/http:\/\///' -e 's/https:\/\///' -e 's/git@//' -e 's/:/\//' -e 's/\.git$//')
 
   if [[ -n "${GITHUB_TOKEN}" ]]; then
     CHART_GIT_REPO="https://${GITHUB_TOKEN}:x-oauth-basic@${CHART_BASE_URL}"


### PR DESCRIPTION
`basename` is too aggressive and removes the hostname and path.