### PR TITLE
Add support for caching Helm chart sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM garethr/kubeval:0.15.0
 
-RUN apk --no-cache add curl bash git openssh-client
+RUN apk --no-cache add curl==7.67.0-r1 bash==5.0.11-r1 git==2.24.3-r0 openssh-client==8.1_p1-r0
 
 COPY LICENSE README.md /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM garethr/kubeval:latest
+FROM garethr/kubeval:0.15.0
 
 RUN apk --no-cache add curl bash git openssh-client
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,33 @@ jobs:
           HRVAL_HEAD_BRANCH: ${{ github.head_ref }}
 ```
 
+## Usage with Helm source caching enabled
+
+Sometimes single Helm release might be referenced multiple times in a single Flux repository,
+for example if staging branch of Helm chart repository is used as a release ref across all staging releases.
+A property named `helmSourcesCacheEnabled` enables caching for such releases,
+so a single Helm repository chafrt version or Git repository ref
+will be retrieved only once, and cached version will be used for validation of another releases which reuse same sources.
+
+
+```yaml
+name: CI
+
+on: [pull_request]
+
+jobs:
+  hrval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Validate Helm Releases in test dir
+        uses: stefanprodan/hrval-action@v3.2.0
+        with:
+          helmRelease: test/
+          helmSourcesCacheEnabled: true
+```
+
+
 ## CI alternatives
 
 The validation scripts can be used in any CI system.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ jobs:
 Sometimes single Helm release might be referenced multiple times in a single Flux repository,
 for example if staging branch of Helm chart repository is used as a release ref across all staging releases.
 A property named `helmSourcesCacheEnabled` enables caching for such releases,
-so a single Helm repository chafrt version or Git repository ref
+so a single Helm repository chart version or Git repository ref
 will be retrieved only once, and cached version will be used for validation of another releases which reuse same sources.
 
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   awsS3Plugin:
     description: '(Optional) AWS S3 Plugin to be used in the helm plugin install command'
     default: ''
+  helmSourcesCacheEnabled:
+    description: '(Optional) Enabled Helm source caching, so same release or ref will not be downloaded twice.'
+    default: 'false'
 outputs:
   numFilesTested:
     description: The number of HelmRelease files which were tested
@@ -41,3 +44,4 @@ runs:
     - ${{ inputs.awsS3Repo }}
     - ${{ inputs.awsS3RepoName }}
     - ${{ inputs.awsS3RepoPlugin }}
+    - ${{ inputs.helmSourcesCacheEnabled }}

--- a/src/hrval-all.sh
+++ b/src/hrval-all.sh
@@ -10,6 +10,13 @@ HRVAL="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/hrval.s
 AWS_S3_REPO=${5-false}
 AWS_S3_REPO_NAME=${6-""}
 AWS_S3_PLUGIN={$7-""}
+HELM_SOURCES_CACHE_ENABLED=${8-""}
+
+if [ "${HELM_SOURCES_CACHE_ENABLED}" == "true" ]; then
+  CACHEDIR=$(mktemp -d)
+else
+  CACHEDIR=""
+fi
 
 if [[ ${HELM_VER} == "v2" ]]; then
     helm init --client-only
@@ -23,7 +30,7 @@ fi
 
 # If the path provided is actually a file, just run hrval against this one file
 if test -f "${DIR}"; then
-  ${HRVAL} ${DIR} ${IGNORE_VALUES} ${KUBE_VER} ${HELM_VER}
+  ${HRVAL} ${DIR} ${IGNORE_VALUES} ${KUBE_VER} ${HELM_VER} ${CACHEDIR}
   exit 0
 fi
 
@@ -47,7 +54,7 @@ DIR_PATH=$(echo ${DIR} | sed "s/^\///;s/\/$//")
 FILES_TESTED=0
 for f in `find ${DIR} -type f -name '*.yaml' -or -name '*.yml'`; do
   if [[ $(isHelmRelease ${f}) == "true" ]]; then
-    ${HRVAL} ${f} ${IGNORE_VALUES} ${KUBE_VER} ${HELM_VER}
+    ${HRVAL} ${f} ${IGNORE_VALUES} ${KUBE_VER} ${HELM_VER} ${CACHEDIR}
     FILES_TESTED=$(( FILES_TESTED+1 ))
   else
     echo "Ignoring ${f} not a HelmRelease"

--- a/src/hrval-all.sh
+++ b/src/hrval-all.sh
@@ -51,7 +51,12 @@ function isHelmRelease {
 
 # Find yaml files in directory recursively
 FILES_TESTED=0
-for f in $(find "${DIR}" -type f -name '*.yaml' -or -name '*.yml'); do
+declare -a FOUND_FILES=()
+while read -r file; do
+    FOUND_FILES+=( "$file" )
+done < <(find "${DIR}" -type f -name '*.yaml' -o -name '*.yml')
+
+for f in "${FOUND_FILES[@]}"; do
   if [[ $(isHelmRelease "${f}") == "true" ]]; then
     ${HRVAL} "${f}" "${IGNORE_VALUES}" "${KUBE_VER}" "${HELM_VER}" "${CACHEDIR}"
     FILES_TESTED=$(( FILES_TESTED+1 ))

--- a/src/hrval-all.sh
+++ b/src/hrval-all.sh
@@ -9,7 +9,7 @@ HELM_VER=${4-v2}
 HRVAL="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/hrval.sh"
 AWS_S3_REPO=${5-false}
 AWS_S3_REPO_NAME=${6-""}
-AWS_S3_PLUGIN={$7-""}
+AWS_S3_PLUGIN="${7-""}"
 HELM_SOURCES_CACHE_ENABLED=${8-""}
 
 if [ "${HELM_SOURCES_CACHE_ENABLED}" == "true" ]; then
@@ -23,14 +23,14 @@ if [[ ${HELM_VER} == "v2" ]]; then
 fi
 
 if [[ ${AWS_S3_REPO} == true ]]; then
-    helm plugin install ${AWS_S3_PLUGIN}
-    helm repo add ${AWS_S3_REPO_NAME} s3:/${AWS_S3_REPO_NAME}/charts
+    helm plugin install "${AWS_S3_PLUGIN}"
+    helm repo add "${AWS_S3_REPO_NAME}" "s3:/${AWS_S3_REPO_NAME}/charts"
     helm repo update
 fi
 
 # If the path provided is actually a file, just run hrval against this one file
 if test -f "${DIR}"; then
-  ${HRVAL} ${DIR} ${IGNORE_VALUES} ${KUBE_VER} ${HELM_VER} ${CACHEDIR}
+  ${HRVAL} "${DIR}" "${IGNORE_VALUES}" "${KUBE_VER}" "${HELM_VER}" "${CACHEDIR}"
   exit 0
 fi
 
@@ -41,7 +41,7 @@ if [ ! -d "$DIR" ]; then
 fi
 
 function isHelmRelease {
-  KIND=$(yq r ${1} kind)
+  KIND=$(yq r "${1}" kind)
   if [[ ${KIND} == "HelmRelease" ]]; then
       echo true
   else
@@ -50,11 +50,10 @@ function isHelmRelease {
 }
 
 # Find yaml files in directory recursively
-DIR_PATH=$(echo ${DIR} | sed "s/^\///;s/\/$//")
 FILES_TESTED=0
-for f in `find ${DIR} -type f -name '*.yaml' -or -name '*.yml'`; do
-  if [[ $(isHelmRelease ${f}) == "true" ]]; then
-    ${HRVAL} ${f} ${IGNORE_VALUES} ${KUBE_VER} ${HELM_VER} ${CACHEDIR}
+for f in $(find "${DIR}" -type f -name '*.yaml' -or -name '*.yml'); do
+  if [[ $(isHelmRelease "${f}") == "true" ]]; then
+    ${HRVAL} "${f}" "${IGNORE_VALUES}" "${KUBE_VER}" "${HELM_VER}" "${CACHEDIR}"
     FILES_TESTED=$(( FILES_TESTED+1 ))
   else
     echo "Ignoring ${f} not a HelmRelease"

--- a/src/hrval-all.sh
+++ b/src/hrval-all.sh
@@ -15,7 +15,7 @@ HELM_SOURCES_CACHE_ENABLED=${8-""}
 if [ "${HELM_SOURCES_CACHE_ENABLED}" == "true" ]; then
   CACHEDIR=$(mktemp -d)
 else
-  CACHEDIR=""
+  CACHEDIR="${CACHEDIR}"
 fi
 
 if [[ ${HELM_VER} == "v2" ]]; then

--- a/src/hrval.sh
+++ b/src/hrval.sh
@@ -161,6 +161,7 @@ function validate {
 
   TMPDIR="$(mktemp -d)"
   CHART_DIR=$(retrieve_sources ${HELM_RELEASE} ${TMPDIR})
+  CHART_PATH=$(yq r ${HELM_RELEASE} spec.chart.path)
 
   HELM_RELEASE_NAME=$(yq r ${HELM_RELEASE} metadata.name)
   HELM_RELEASE_NAMESPACE=$(yq r ${HELM_RELEASE} metadata.namespace)

--- a/src/hrval.sh
+++ b/src/hrval.sh
@@ -107,7 +107,8 @@ function retrieve_sources {
       fi
 
     else
-      # Retrieve existing resource from cache directory, or use new if it exists.
+      # Retrieve existing helm chart source from cache, 
+      # or create new cache directory if it does not exist yet.
 
       if [[ -z "${CHART_PATH}" ]]; then
         # Caches releases from Helm repos

--- a/src/hrval.sh
+++ b/src/hrval.sh
@@ -2,11 +2,11 @@
 
 set -o errexit
 
-HELM_RELEASE=${1}
-IGNORE_VALUES=${2}
-KUBE_VER=${3-master}
-HELM_VER=${4-v2}
-CACHEDIR=${5-""}
+HELM_RELEASE="${1}"
+IGNORE_VALUES="${2}"
+KUBE_VER="${3-master}"
+HELM_VER="${4-v2}"
+CACHEDIR="${5-""}"
 
 if test ! -f "${HELM_RELEASE}"; then
   echo "\"${HELM_RELEASE}\" Helm release file not found!"
@@ -16,8 +16,8 @@ fi
 echo "Processing ${HELM_RELEASE}"
 
 function isHelmRelease {
-  KIND=$(yq r ${1} kind)
-  if [[ ${KIND} == "HelmRelease" ]]; then
+  KIND=$(yq r "${1}" kind)
+  if [[ "${KIND}" == "HelmRelease" ]]; then
       echo true
   else
     echo false
@@ -26,41 +26,41 @@ function isHelmRelease {
 
 
 function download {
-  CHART_REPO=$(yq r ${1} spec.chart.repository)
-  CHART_NAME=$(yq r ${1} spec.chart.name)
-  CHART_VERSION=$(yq r ${1} spec.chart.version)
+  CHART_REPO="$(yq r "${1}" spec.chart.repository)"
+  CHART_NAME="$(yq r "${1}" spec.chart.name)"
+  CHART_VERSION="$(yq r "${1}" spec.chart.version)"
   CHART_DIR=${2}/${CHART_NAME}
 
-  CHART_REPO_MD5=`/bin/echo $CHART_REPO | /usr/bin/md5sum | cut -f1 -d" "`
+  CHART_REPO_MD5=$(/bin/echo "${CHART_REPO}" | /usr/bin/md5sum | cut -f1 -d" ")
 
-  if [[ ${HELM_VER} == "v3" ]]; then
-    helmv3 repo add ${CHART_REPO_MD5} ${CHART_REPO}
+  if [[ "${HELM_VER}" == "v3" ]]; then
+    helmv3 repo add "${CHART_REPO_MD5}" "${CHART_REPO}"
     helmv3 repo update
-    helmv3 fetch --version ${CHART_VERSION} --untar ${CHART_REPO_MD5}/${CHART_NAME} --untardir ${2}
+    helmv3 fetch --version "${CHART_VERSION}" --untar "${CHART_REPO_MD5}/${CHART_NAME}" --untardir "${2}"
   else
-    helm repo add ${CHART_REPO_MD5} ${CHART_REPO}
+    helm repo add "${CHART_REPO_MD5}" "${CHART_REPO}"
     helm repo update
-    helm fetch --version ${CHART_VERSION} --untar ${CHART_REPO_MD5}/${CHART_NAME} --untardir ${2}
+    helm fetch --version "${CHART_VERSION}" --untar "${CHART_REPO_MD5}/${CHART_NAME}" --untardir "${2}"
   fi
 
-  echo ${CHART_DIR}
+  echo "${CHART_DIR}"
 }
 
 
 function fetch {
-  cd ${1}
+  cd "${1}"
   git init -q
-  git remote add origin ${3}
+  git remote add origin "${3}"
   git fetch -q origin
-  git checkout -q ${4}
-  cd ${5}
-  echo ${2}
+  git checkout -q "${4}"
+  cd "${5}"
+  echo "${2}"
 }
 
 
 function clone {
   ORIGIN=$(git rev-parse --show-toplevel)
-  CHART_GIT_REPO=$(yq r ${1} spec.chart.git)
+  CHART_GIT_REPO=$(yq r "${1}" spec.chart.git)
   RELEASE_GIT_REPO=$(git remote get-url origin)
 
   CHART_BASE_URL=$(echo "${CHART_GIT_REPO}" | sed -e 's/ssh:\/\///' -e 's/http:\/\///' -e 's/https:\/\///' -e 's/git@//' -e 's/:/\//' -e 's/\.git$//')
@@ -72,38 +72,38 @@ function clone {
     CHART_GIT_REPO="https://gitlab-ci-token:${GITLAB_CI_TOKEN}@${CHART_BASE_URL}"
   fi
 
-  GIT_REF=$(yq r ${1} spec.chart.ref)
-  CHART_PATH=$(yq r ${1} spec.chart.path)
+  GIT_REF=$(yq r "${1}" spec.chart.ref)
+  CHART_PATH=$(yq r "${1}" spec.chart.path)
 
-  if [ ! -z ${3} ]; then
-    if [[ "${CHART_BASE_URL}" == "${RELEASE_BASE_URL}" ]] && [[ ${GIT_REF} == "${4}" ]]; then
+  if [ -n "${3}" ]; then
+    if [[ "${CHART_BASE_URL}" == "${RELEASE_BASE_URL}" ]] && [[ "${GIT_REF}" == "${4}" ]]; then
       # Clone from the head repository branch/ref
-      fetch ${2} ${2}/${CHART_PATH} ${RELEASE_GIT_REPO} ${3} ${ORIGIN}
+      fetch "${2}" "${2}/${CHART_PATH}" "${RELEASE_GIT_REPO}" "${3}" "${ORIGIN}"
     else
       # Regular clone
-      fetch ${2} ${2}/${CHART_PATH} ${CHART_GIT_REPO} ${GIT_REF} ${ORIGIN}
+      fetch "${2}" "${2}/${CHART_PATH}" "${CHART_GIT_REPO}" "${GIT_REF}" "${ORIGIN}"
     fi
   else
-      fetch ${2} ${2}/${CHART_PATH} ${CHART_GIT_REPO} ${GIT_REF} ${ORIGIN}
+      fetch "${2}" "${2}/${CHART_PATH}" "${CHART_GIT_REPO}" "${GIT_REF}" "${ORIGIN}"
   fi
 }
 
 
 function retrieve_sources {
-    HELM_RELEASE=${1}
-    TMPDIR=${2}
+    HELM_RELEASE="${1}"
+    TMPDIR="${2}"
 
-    CHART_PATH=$(yq r ${HELM_RELEASE} spec.chart.path)
+    CHART_PATH=$(yq r "${HELM_RELEASE}" spec.chart.path)
 
     if [[ -z "${CACHEDIR}" ]]; then
 
       # Retrieve files directly into tempdir
       if [[ -z "${CHART_PATH}" ]]; then
         >&2 echo "Downloading to ${TMPDIR}"
-        CHART_DIR=$(download ${HELM_RELEASE} ${TMPDIR} ${HELM_VER}| tail -n1)
+        CHART_DIR=$(download "${HELM_RELEASE}" "${TMPDIR}" "${HELM_VER}" | tail -n1)
       else
         >&2 echo "Cloning to ${TMPDIR}"
-        CHART_DIR=$(clone ${HELM_RELEASE} ${TMPDIR} ${HRVAL_HEAD_BRANCH} ${HRVAL_BASE_BRANCH} | tail -n1)
+        CHART_DIR=$(clone "${HELM_RELEASE}" "${TMPDIR}" "${HRVAL_HEAD_BRANCH}" "${HRVAL_BASE_BRANCH}" | tail -n1)
       fi
 
     else
@@ -112,89 +112,89 @@ function retrieve_sources {
       if [[ -z "${CHART_PATH}" ]]; then
         # Caches releases from Helm repos
 
-        CHART_REPO=$(yq r ${HELM_RELEASE} spec.chart.repository)
-        CHART_REPO_MD5=`/bin/echo $CHART_REPO | /usr/bin/md5sum | cut -f1 -d" "`
-        CHART_NAME=$(yq r ${HELM_RELEASE} spec.chart.name)
-        CHART_VERSION=$(yq r ${HELM_RELEASE} spec.chart.version)
-        CHART_LOCAL_PATH=${CACHEDIR}/${CHART_REPO_MD5}/${CHART_NAME}/${CHART_VERSION}
+        CHART_REPO=$(yq r "${HELM_RELEASE}" spec.chart.repository)
+        CHART_REPO_MD5=$(/bin/echo "${CHART_REPO}" | /usr/bin/md5sum | cut -f1 -d" ")
+        CHART_NAME=$(yq r "${HELM_RELEASE}" spec.chart.name)
+        CHART_VERSION=$(yq r "${HELM_RELEASE}" spec.chart.version)
+        CHART_LOCAL_PATH="${CACHEDIR}/${CHART_REPO_MD5}/${CHART_NAME}/${CHART_VERSION}"
 
         if [[ ! -d ${CHART_LOCAL_PATH} ]]; then
-          mkdir -p ${CHART_LOCAL_PATH}
+          mkdir -p "${CHART_LOCAL_PATH}"
           >&2 echo "Downloading to ${CHART_LOCAL_PATH}"
-          CHART_DIR=$(download ${HELM_RELEASE} ${CHART_LOCAL_PATH} ${HELM_VER}| tail -n1)
+          CHART_DIR=$(download "${HELM_RELEASE}" "${CHART_LOCAL_PATH}" "${HELM_VER}" | tail -n1)
         else
           >&2 echo "Using cached sources from ${CHART_LOCAL_PATH}"
-          CHART_DIR=${CHART_LOCAL_PATH}/${CHART_NAME}
+          CHART_DIR="${CHART_LOCAL_PATH}/${CHART_NAME}"
         fi
 
       else
           # Caches releases from Git repos
 
-          CHART_GIT_REPO=$(yq r ${1} spec.chart.git)
-          CHART_PATH=$(yq r ${1} spec.chart.path)
-          GIT_REF=$(yq r ${1} spec.chart.ref)
+          CHART_GIT_REPO=$(yq r "${1}" spec.chart.git)
+          CHART_PATH=$(yq r "${1}" spec.chart.path)
+          GIT_REF=$(yq r "${1}" spec.chart.ref)
 
-          CHART_LOCAL_PATH=${CACHEDIR}/${CHART_GIT_REPO}/${GIT_REF}
+          CHART_LOCAL_PATH="${CACHEDIR}/${CHART_GIT_REPO}/${GIT_REF}"
 
-          if [[ ! -d ${CHART_LOCAL_PATH} ]]; then
-            mkdir -p ${CHART_LOCAL_PATH}
+          if [[ ! -d "${CHART_LOCAL_PATH}" ]]; then
+            mkdir -p "${CHART_LOCAL_PATH}"
             >&2 echo "Cloning to ${CHART_LOCAL_PATH}"
-            CHART_DIR=$(clone ${HELM_RELEASE} ${CHART_LOCAL_PATH} ${HRVAL_HEAD_BRANCH} ${HRVAL_BASE_BRANCH} | tail -n1)
+            CHART_DIR=$(clone "${HELM_RELEASE}" "${CHART_LOCAL_PATH}" "${HRVAL_HEAD_BRANCH}" "${HRVAL_BASE_BRANCH}" | tail -n1)
           else
             >&2 echo "Using cached sources from ${CHART_LOCAL_PATH}"
-            CHART_DIR=${CHART_LOCAL_PATH}/${CHART_PATH}
+            CHART_DIR="${CHART_LOCAL_PATH}/${CHART_PATH}"
           fi
 
         fi
 
     fi
 
-    echo ${CHART_DIR}
+    echo "${CHART_DIR}"
 }
 
 
 function validate {
-  if [[ $(isHelmRelease ${HELM_RELEASE}) == "false" ]]; then
+  if [[ $(isHelmRelease "${HELM_RELEASE}") == "false" ]]; then
     echo "\"${HELM_RELEASE}\" is not of kind HelmRelease!"
     exit 1
   fi
 
   TMPDIR="$(mktemp -d)"
-  CHART_DIR=$(retrieve_sources ${HELM_RELEASE} ${TMPDIR})
-  CHART_PATH=$(yq r ${HELM_RELEASE} spec.chart.path)
+  CHART_DIR=$(retrieve_sources "${HELM_RELEASE}" "${TMPDIR}")
+  CHART_PATH=$(yq r "${HELM_RELEASE}" spec.chart.path)
 
-  HELM_RELEASE_NAME=$(yq r ${HELM_RELEASE} metadata.name)
-  HELM_RELEASE_NAMESPACE=$(yq r ${HELM_RELEASE} metadata.namespace)
+  HELM_RELEASE_NAME=$(yq r "${HELM_RELEASE}" metadata.name)
+  HELM_RELEASE_NAMESPACE=$(yq r "${HELM_RELEASE}" metadata.namespace)
 
-  if [[ ${IGNORE_VALUES} == "true" ]]; then
+  if [[ "${IGNORE_VALUES}" == "true" ]]; then
     echo "Ingnoring Helm release values"
-    echo "" > ${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml
+    echo "" > "${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml"
   else
     echo "Extracting values to ${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml"
-    yq r ${HELM_RELEASE} spec.values > ${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml
+    yq r "${HELM_RELEASE}" spec.values > "${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml"
   fi
 
   echo "Writing Helm release to ${TMPDIR}/${HELM_RELEASE_NAME}.release.yaml"
   if [[ ${HELM_VER} == "v3" ]]; then
     if [[ "${CHART_PATH}" ]]; then
-      helmv3 dependency build ${CHART_DIR}
+      helmv3 dependency build "${CHART_DIR}"
     fi
-    helmv3 template ${HELM_RELEASE_NAME} ${CHART_DIR} \
-      --namespace ${HELM_RELEASE_NAMESPACE} \
+    helmv3 template "${HELM_RELEASE_NAME}" "${CHART_DIR}" \
+      --namespace "${HELM_RELEASE_NAMESPACE}" \
       --skip-crds=true \
-      -f ${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml > ${TMPDIR}/${HELM_RELEASE_NAME}.release.yaml
+      -f "${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml" > "${TMPDIR}/${HELM_RELEASE_NAME}.release.yaml"
   else
     if [[ "${CHART_PATH}" ]]; then
-      helm dependency build ${CHART_DIR}
+      helm dependency build "${CHART_DIR}"
     fi
-    helm template ${CHART_DIR} \
-      --name ${HELM_RELEASE_NAME} \
-      --namespace ${HELM_RELEASE_NAMESPACE} \
-      -f ${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml > ${TMPDIR}/${HELM_RELEASE_NAME}.release.yaml
+    helm template "${CHART_DIR}" \
+      --name "${HELM_RELEASE_NAME}" \
+      --namespace "${HELM_RELEASE_NAMESPACE}" \
+      -f "${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml" > "${TMPDIR}/${HELM_RELEASE_NAME}.release.yaml"
   fi
 
   echo "Validating Helm release ${HELM_RELEASE_NAME}.${HELM_RELEASE_NAMESPACE} against Kubernetes ${KUBE_VER}"
-  kubeval --strict --ignore-missing-schemas --kubernetes-version ${KUBE_VER} ${TMPDIR}/${HELM_RELEASE_NAME}.release.yaml
+  kubeval --strict --ignore-missing-schemas --kubernetes-version "${KUBE_VER}" "${TMPDIR}/${HELM_RELEASE_NAME}.release.yaml"
 }
 
 validate


### PR DESCRIPTION
Sometimes single Helm release might be referenced multiple times in a single Flux repository,
for example, if the staging branch of Helm chart repository is used as a release ref across all staging releases.

In this case, a download delay for each release's chart source acts as a time multiplier for the whole `hrval-action` run.

This patch adds support for the new `helmSourcesCacheEnabled` parameter, which allows for caching Helm sources on a local filesystem, so any distinct chart git ref of chart version is downloaded once, and the cached chart source version is used for any subsequent releases values validation.
