### PR TITLE
fix: allow YAML anchors to be interpreted in the values

### DIFF
--- a/src/deps.sh
+++ b/src/deps.sh
@@ -2,12 +2,12 @@
 
 set -o errexit
 
-curl -sL https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+curl -sL "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 
 curl -sL https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
 curl -sSL https://get.helm.sh/helm-v2.16.3-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64
-helm init --client-only --kubeconfig=$HOME/.kube/kubeconfig
+helm init --client-only --kubeconfig="${HOME}/.kube/kubeconfig"
 
 curl -sSL https://get.helm.sh/helm-v3.1.1-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helmv3 && rm -rf linux-amd64
 helmv3 version

--- a/src/deps.sh
+++ b/src/deps.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 curl -sL https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 
-curl -sL https://github.com/mikefarah/yq/releases/download/3.1.0/yq_linux_amd64 -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+curl -sL https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
 curl -sSL https://get.helm.sh/helm-v2.16.3-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64
 helm init --client-only --kubeconfig=$HOME/.kube/kubeconfig

--- a/src/hrval.sh
+++ b/src/hrval.sh
@@ -172,7 +172,7 @@ function validate {
     echo "" > "${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml"
   else
     echo "Extracting values to ${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml"
-    yq r "${HELM_RELEASE}" spec.values > "${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml"
+    yq r -X "${HELM_RELEASE}" spec.values > "${TMPDIR}/${HELM_RELEASE_NAME}.values.yaml"
   fi
 
   echo "Writing Helm release to ${TMPDIR}/${HELM_RELEASE_NAME}.release.yaml"


### PR DESCRIPTION
In the case where YAML anchors and aliases are used in values.yaml e.g.:
```yaml
spec:
  releaseName: istio-operator
  chart:
    git: https://github.com/istio/istio.git
    ref: &version 1.7.5
    path: manifests/charts/istio-operator/
  values:
    hub: docker.io/istio
    tag: *version
```

one will see the following error since the values are not interpreted.
```
Error: failed to parse /tmp/tmp.DBpoGP/values.yaml:
error converting YAML to JSON: yaml: unknown anchor 'version' referenced
```

 `yq` allows for this, and this update correctly interprets the values: `yq r -X istio-operator.yaml spec.values` gives

```yaml
hub: docker.io/istio
tag: 1.7.5
```
