### PR TITLE
Update deps.sh

### DIFF
--- a/src/deps.sh
+++ b/src/deps.sh
@@ -6,8 +6,8 @@ curl -sL "https://storage.googleapis.com/kubernetes-release/release/$(curl -s ht
 
 curl -sL https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
-curl -sSL https://get.helm.sh/helm-v2.16.3-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64
+curl -sSL https://get.helm.sh/helm-v2.17.0-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64
 helm init --client-only --kubeconfig="${HOME}/.kube/kubeconfig"
 
-curl -sSL https://get.helm.sh/helm-v3.1.1-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helmv3 && rm -rf linux-amd64
+curl -sSL https://get.helm.sh/helm-v3.4.0-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helmv3 && rm -rf linux-amd64
 helmv3 version


### PR DESCRIPTION
Updating helm versions to avoid the issue:
```
Error: error initializing: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
```

https://helm.sh/blog/new-location-stable-incubator-charts/