### PR TITLE
Updated deps.sh with new helm versions

### DIFF
--- a/src/deps.sh
+++ b/src/deps.sh
@@ -6,8 +6,8 @@ curl -sL "https://storage.googleapis.com/kubernetes-release/release/$(curl -s ht
 
 curl -sL https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
-curl -sSL https://get.helm.sh/helm-v2.16.3-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64
+curl -sSL https://get.helm.sh/helm-v2.17.0-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64
 helm init --client-only --kubeconfig="${HOME}/.kube/kubeconfig"
 
-curl -sSL https://get.helm.sh/helm-v3.1.1-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helmv3 && rm -rf linux-amd64
+curl -sSL https://get.helm.sh/helm-v3.4.0-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helmv3 && rm -rf linux-amd64
 helmv3 version


### PR DESCRIPTION
Updated helm versions to align with https://helm.sh/blog/new-location-stable-incubator-charts/
This leads to build error in the test dir.
Requirements.lock in the fluxcd chart still points to the old dir leading to Error: requirements.lock is out of sync with requirements.yaml
once removed test should work as expected