### PR TITLE
fix(helm): specify new stable repo for helm v2.16.3

### DIFF
--- a/src/deps.sh
+++ b/src/deps.sh
@@ -7,7 +7,7 @@ curl -sL "https://storage.googleapis.com/kubernetes-release/release/$(curl -s ht
 curl -sL https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
 curl -sSL https://get.helm.sh/helm-v2.16.3-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64
-helm init --client-only --kubeconfig="${HOME}/.kube/kubeconfig"
+helm init --client-only --kubeconfig="${HOME}/.kube/kubeconfig" --stable-repo-url=https://charts.helm.sh/stable
 
 curl -sSL https://get.helm.sh/helm-v3.1.1-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helmv3 && rm -rf linux-amd64
 helmv3 version

--- a/src/hrval-all.sh
+++ b/src/hrval-all.sh
@@ -53,7 +53,7 @@ else
 fi
 
 if [[ ${HELM_VER} == "v2" ]]; then
-    helm init --client-only
+    helm init --client-only --stable-repo-url=https://charts.helm.sh/stable
 fi
 
 if [[ ${AWS_S3_REPO} == true ]]; then


### PR DESCRIPTION
The repository that helm v2.16.3 uses is now depreciated, moved to https://charts.helm.sh/stable

in deps.sh, helm init crashes unless the new stable repo location is specifically set, otherwise the error below is seen
```
Error: error initializing:
Looks like "https://kubernetes-charts.storage.googleapis.com"
is not a valid chart repository or cannot be reached:
Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
```

see https://stackoverflow.com/questions/65407317/helm-init-failed-is-not-a-valid-chart-repository-or-cannot-be-reached-failed-to